### PR TITLE
Exclude .vite from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cookies.txt
 config.js
 coverage
 dist
+**/.vite


### PR DESCRIPTION
You offered a bounty for preventing this issue going forward 🏴‍☠️ 

Now that the files have been tracked, remember to remove them with:
```sh
git rm -r .vite* && git commit -am "remove(.vite) files accidentally committed before"
```